### PR TITLE
feat: migrate to vim.api.nvim_set_hl()

### DIFF
--- a/lua/vague/highlights.lua
+++ b/lua/vague/highlights.lua
@@ -2,24 +2,10 @@ local curr_internal_conf = require("vague.config.internal").current
 local groups = require("vague.groups")
 local M = {}
 
----@param highlights table <string, table>
+---@param highlights table <string, vim.api.keyset.highlight>
 local function set_vim_highlights(highlights)
-  for name, setting in pairs(highlights) do
-    if setting.gui == "bold" and not curr_internal_conf.bold then
-      setting.gui = "none"
-    elseif setting.gui == "italic" and not curr_internal_conf.italic then
-      setting.gui = "none"
-    end
-    vim.api.nvim_command(
-      string.format(
-        "highlight %s guifg=%s guibg=%s guisp=%s gui=%s",
-        name,
-        setting.fg or "none",
-        setting.bg or "none",
-        setting.sp or "none",
-        setting.gui or "none"
-      )
-    )
+  for name, highlight in pairs(highlights) do
+	vim.api.nvim_set_hl(0, name, highlight)
   end
 end
 


### PR DESCRIPTION
Replace string-formatted `:highlight` command with the native Lua API `vim.api.nvim_set_hl()`. This change improves performance by avoiding command-string construction and enables full support for all keys supported in `vim.api.keyset.highlight`.

## Breaking changes

This change breaks compatibility with user configs using the old format:
```lua
-- old
{ fg = "#fff", bg = "#000", gui = "italic" }

-- new
{ fg = "#fff", bg = "#000", italic = true }
```
The `vim.api.keyset.highlight` has not `gui` field and instead uses separate booleans (bold, italic, etc.). This also allows specifying multiple styles simultaneously, which was not easily possible with the previous gui string field.
This should be easy to update in configs, but it's worth calling out explicitly.

## Config structure
This change also surfaces a broader design question:

While on_highlights will give users full control over all hl-group properties, the config’s styling-related options (bold, italic, etc.) feel increasingly limited—and possibly redundant.

My suggestion would be to:

 a) Keep only a few top-level global toggles (e.g. italic = false, transparent = true) that apply across all groups
 
 b) Drop the plugins section, which is already somewhat outdated and less reliable than editing highlight groups directly via on_highlights

Or another option that I see is to expose `vim.api.keyset.highlight` for each config style, so it will be not `plugins.cmp.match = "italic"` but `plugins.cmp.match = { italic = true }`. But it feels like aliasing already existing API of hl-groups.

---

Now that this is taking shape, it feels like a v2-level change. I'm uncertain about how best to approach backward compatibility:
  - Attempt to keep the old format supported and mark it as deprecated?
  - Or break it cleanly and ask users to migrate, given that the change is relatively minor and the new API is clearly better?

I’m leaning toward a clean break—most users likely won’t be affected much, and it would simplify the code and config model.

That said, I’d really appreciate your input and overall vision for this. I’m happy to adapt and move forward with whichever direction we choose.