### PR TITLE
feat(groups): add OkMsg hl-group

### DIFF
--- a/lua/vague/groups/common.lua
+++ b/lua/vague/groups/common.lua
@@ -22,6 +22,7 @@ M.get_colors = function(conf)
     debugPC          = { fg = c.bg, bg = c.fg },
     debugBreakpoint  = { fg = c.bg, bg = c.operator },
     Directory        = { fg = c.hint },
+    OkMsg            = { fg = c.plus },
     ErrorMsg         = { fg = c.error, gui = "bold" },
     EndOfBuffer      = { fg = c.comment or c.bg },
     FloatBorder      = { fg = c.floatBorder, bg = conf.transparent and "none" or c.bg },


### PR DESCRIPTION
Adds support for the new highlight group introduced in https://github.com/neovim/neovim/pull/35533 (currently available in nightly).
