### PR TITLE
fix: syntax_on check is always true

### DIFF
--- a/lua/vague/init.lua
+++ b/lua/vague/init.lua
@@ -19,7 +19,9 @@ end
 --- so this function is the equivalent to calling |:colorscheme| so use that instead
 M._colorscheme = function()
   vim.cmd("highlight clear")
-  if vim.fn.has("syntax_on") then vim.cmd("syntax reset") end
+  if vim.fn.exists("syntax_on") == 1 then
+    vim.cmd("syntax reset")
+  end
   vim.g.colors_name = "vague"
 
   require("vague.highlights").set_highlights()


### PR DESCRIPTION
Firstly, has() and exists() return 0/1, so the condition is always true in Lua.

Secondly, has() checks feature support, but what we want is to check whether 'syntax_on' is defined.